### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that provides PostgreSQL database management capabilities. This server assists with analyzing existing PostgreSQL setups, providing implementation guidance, and debugging database issues.
 
+<a href="https://glama.ai/mcp/servers/bnw58zblt1"><img width="380" height="200" src="https://glama.ai/mcp/servers/bnw58zblt1/badge" alt="PostgreSQL Server MCP server" /></a>
+
 ## Features
 
 ### 1. Database Analysis (`analyze_database`)


### PR DESCRIPTION
This PR adds a badge for the [PostgreSQL MCP Server](https://glama.ai/mcp/servers/bnw58zblt1) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/bnw58zblt1"><img width="380" height="200" src="https://glama.ai/mcp/servers/bnw58zblt1/badge" alt="PostgreSQL Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.